### PR TITLE
Open pdf links without page number

### DIFF
--- a/org-pdftools.el
+++ b/org-pdftools.el
@@ -190,7 +190,8 @@ Can be one of highlight/underline/strikeout/squiggly."
                   (pathlist (split-string paths "%&%")))
              (pdf-occur-search
               pathlist
-              occur-search-string))))))
+              occur-search-string)))
+          ((org-open-file link 1)))))
 
 ;;;###autoload
 (defun org-pdftools-open (link)


### PR DESCRIPTION
It seems links without a page number do not work, e.g.


+ `[[pdftools:/home/test.pdf::1][This works]]`
+ `[[pdftools:/home/test.pdf][This fails]]`


This modification fixes that.