### PR TITLE
Add org-pdftools-setup-link hook

### DIFF
--- a/README.org
+++ b/README.org
@@ -13,16 +13,9 @@ You can now install ~org-pdftools~ and ~org-noter-pdftools~ from MELPA!
 
 #+BEGIN_SRC elisp
 (use-package org-pdftools
-  :init (setq org-pdftools-root-dir /path/you/store/pdfs
-                org-pdftools-search-string-separator "??")
-  :after org
-  :config
-    (org-link-set-parameters "pdftools"
-                             :follow #'org-pdftools-open
-                             :complete #'org-pdftools-complete-link
-                             :store #'org-pdftools-store-link
-                             :export #'org-pdftools-export)
-    (add-hook 'org-store-link-functions 'org-pdftools-store-link)))
+  :hook (org-load . org-pdftools-setup-link)
+  :init (setq org-pdftools-root-dir "/path/you/store/pdfs"
+              org-pdftools-search-string-separator "??"))
 
 (use-package org-noter-pdftools
   :after org-noter)

--- a/org-pdftools.el
+++ b/org-pdftools.el
@@ -373,6 +373,18 @@ and append it. ARG is passed to `org-link-complete-file'."
     "1")))
 
 
+;;;###autoload
+(defun org-pdftools-setup-link (&optional protcol)
+  "Set up pdftools: links in org-mode."
+  (setq org-pfdtools-protocol (or protocol org-pfdtools-protocol))
+  (org-link-set-parameters org-pfdtools-protocol
+                           :follow #'org-pdftools-open
+                           :complete #'org-pdftools-complete-link
+                           :store #'org-pdftools-store-link
+                           :export #'org-pdftools-export)
+  (add-hook 'org-store-link-functions #'org-pdftools-store-link))
+
+
 (defun org-pdftools-get-path (rel-path)
   "Get full path from REL-PATH."
   (let* ((fullpath (expand-file-name rel-path org-pdftools-root-dir))


### PR DESCRIPTION
This PR depends on #26. If #26 is rejected, this can be generalized to not use the variable it introduces.

It adds a `org-pdftools-setup-link` hook that can be added to `org-load-hook` to simplify setting up this plugin's links in org-mode.