### PR TITLE
org-pdftools-store-link: fix link isearch string match

### DIFF
--- a/org-pdftools.el
+++ b/org-pdftools.el
@@ -324,7 +324,7 @@ Can be one of highlight/underline/strikeout/squiggly."
                                                     (mapconcat 'identity (pdf-view-active-region-text) ? ))))
                 (page (number-to-string (pdf-view-current-page)))
                 (link (org-pdftools-get-link))
-                (isearchstr (if (string-match ".*??\\(.*\\)" link)
+                (isearchstr (if (string-match ".*\\?\\?\\(.*\\)" link)
                                 (match-string 1 link)))
                 (desc (funcall org-pdftools-get-desc-function file page (or quot isearchstr))))
            (org-link-store-props


### PR DESCRIPTION
The pdftools link format uses the string "??" to separate the isearch
string match portion of the link. The regular expression used to
extract that string in org-pdftools-store-link before this commit did
not quote these question marks so that they specify zero or one of the
previous item rather than literal question marks, resulting in the
entire link always matching and being used for the "Quoting" section
of the default description.