### PR TITLE
Small fixes to `org-pdftools-export`

### DIFF
--- a/org-pdftools.el
+++ b/org-pdftools.el
@@ -355,7 +355,8 @@ Can be one of highlight/underline/strikeout/squiggly."
             (setq page loc)))
       (setq path link))
 
-    (setq path (org-link-escape path))
+    ;; `org-export-file-uri` expands the filename correctly
+    (setq path (org-export-file-uri (org-link-escape path)))
 
     (cond ((eq format 'html)
            (format

--- a/org-pdftools.el
+++ b/org-pdftools.el
@@ -345,7 +345,7 @@ Can be one of highlight/underline/strikeout/squiggly."
 ;;;###autoload
 (defun org-pdftools-export (link description format)
   "Export the pdfview LINK with DESCRIPTION for FORMAT from Org files."
-  (let* (path desc loc page)
+  (let* (path loc page)
     (if (string-match "\\(.+\\)::\\(.*\\)" link)
         (progn
           (setq path (match-string 1 link))
@@ -363,14 +363,14 @@ Can be one of highlight/underline/strikeout/squiggly."
             "<a href=\"%s#page=%s\">%s</a>"
             path
             page
-            desc))
+            description))
           ((eq format 'latex)
            (format
             "\\href{%s}{%s}"
             path
-            desc))
+            description))
           ((eq format 'ascii)
-           (format "%s (%s)" desc path))
+           (format "%s (%s)" description path))
           (t path))))
 
 ;;;###autoload


### PR DESCRIPTION
On master we have the following behavior:
```emacs-lisp
(org-pdftools-export
 "~/test.pdf::14++0.00;;annot-14-2"
 "test.pdf: Page 1"
 'html)
;; => "<a href=\"~/test.pdf#page=14\">nil</a>"

(org-pdftools-export
 "~/test.pdf::14++0.00;;annot-14-2"
 "test.pdf: Page 1"
 'latex)
;; => "\\href{~/test.pdf}{nil}"
```
while on this branch we have the (seemingly correct) behavior:
```emacs-lisp
(org-pdftools-export
 "~/test.pdf::14++0.00;;annot-14-2"
 "test.pdf: Page 1"
 'html)
;; => "<a href=\"file:///home/tor/test.pdf#page=14\">test.pdf: Page 1</a>"

(org-pdftools-export
 "~/test.pdf::14++0.00;;annot-14-2"
 "test.pdf: Page 1"
 'latex)
;; => "\\href{file:///home/tor/test.pdf}{test.pdf: Page 1}"
```
This will result in links which can be opened by clicking on them in their respective viewers :+1: