### PR TITLE
make "Comment" heading optional…

### DIFF
--- a/org-noter-pdftools.el
+++ b/org-noter-pdftools.el
@@ -103,6 +103,11 @@ To use this, `org-noter-pdftools-use-org-id' has to be t."
   :group 'org-noter
   :type 'boolean)
 
+(defcustom org-noter-pdftools-insert-comment-heading t
+  "When non-nil, insert a \"Content\" heading above the content of an annotation (underline, highlight)"
+  :group 'org-noter
+  :type 'boolean)
+
 (cl-defstruct org-noter-pdftools--location
   path page height annot-id search-string original-property)
 
@@ -620,7 +625,8 @@ Only available with PDF Tools."
                     (org-noter--insert-heading (1+ level) "Contents"))
                  (insert (car contents)))
                (when (cdr contents)
-                 (org-noter--insert-heading (1+ level) "Comment")
+                 (when org-noter-pdftools-insert-comment-heading
+                     (org-noter--insert-heading (1+ level) "Comment"))
                  (insert (cdr contents)))))
 
            (setq ast (org-noter--parse-root))


### PR DESCRIPTION
Introduce a variable `org-noter-pdftools-insert-comment-heading` to customize insertion of an additional headline "Comment"
Similar to #62