### PR TITLE
Fix height handling

### DIFF
--- a/org-pdftools.el
+++ b/org-pdftools.el
@@ -175,19 +175,11 @@ Can be one of highlight/underline/strikeout/squiggly."
                     (with-selected-window
                         (org-noter--get-doc-window)
                       (image-set-window-vscroll
-                       (round
-                        (/
-                         (*
-                          (string-to-number height)
-                          (cdr (pdf-view-image-size)))
-                         (frame-char-height))))))
+                       (* (string-to-number height)
+                          (cdr (pdf-view-image-size))))))
                  (image-set-window-vscroll
-                  (round
-                   (/
-                    (*
-                     (string-to-number height)
-                     (cdr (pdf-view-image-size)))
-                    (frame-char-height))))))
+                  (* (string-to-number height)
+                     (cdr (pdf-view-image-size))))))
              (when (and annot-id
                         (not (string-empty-p annot-id)))
                (if (bound-and-true-p org-noter--session)


### PR DESCRIPTION
Hi, the height parameter of org-pdftools link seems to be treated incorrectly: `C-c C-o` jumps to a point that's way too high (i.e. way too close to the top of the page).  There's code in `org-pdftools-open-pdftools` that converts the height (given as a fraction of page height) to number of lines before giving it to `image-set-window-vscroll`, but `image-set-window-vscroll` wants the input specified in pixels, not lines.  This PR removes the conversion to lines.