### PR TITLE
incorporate necessary configuration into org-pdftools.el

### DIFF
--- a/README.org
+++ b/README.org
@@ -16,8 +16,7 @@ Run ~M-x pdf-tools-install~ after installation of ~pdftools~ if you haven't done
   ;; Your org-noter config ........
   (require 'org-noter-pdftools))
 
-(use-package org-pdftools
-  :hook (org-mode . org-pdftools-setup-link))
+(use-package org-pdftools)
 
 (use-package org-noter-pdftools
   :after org-noter

--- a/org-pdftools.el
+++ b/org-pdftools.el
@@ -429,5 +429,8 @@ and append it. ARG is passed to `org-link-complete-file'."
       "Page:"
       "1"))))
 
+(with-eval-after-load 'org
+  (add-hook 'org-mode-hook #'org-pdftools-setup-link))
+
 (provide 'org-pdftools)
 ;;; org-pdftools.el ends here


### PR DESCRIPTION
Is there a reason that the org-mode-hook is set in the configuration?  The basic functionality of storing and inserting links doesn't work without it.  Is there another way?

Also, why aren't the two functions in the org-noter-pdftools config included in the package?  I haven't tried them, so I have no sense of how necessary they are.