### PR TITLE
add page-number support

### DIFF
--- a/org-noter-pdftools.el
+++ b/org-noter-pdftools.el
@@ -416,7 +416,7 @@ To use this, `org-noter-pdftools-use-org-id' has to be t."
          nil)))))
 
 ;; TODO(nox): Implement interface for skeleton creation
-(defun org-noter-pdftools-create-skeleton ()
+(defun org-noter-pdftools-create-skeleton (&optional page-number)
   "Create notes skeleton with the PDF outline or annotations.
 Only available with PDF Tools."
   (interactive)
@@ -505,7 +505,7 @@ Only available with PDF Tools."
 
              (setq insert-contents (y-or-n-p "Should we insert the annotations contents? "))
 
-             (dolist (item (pdf-info-getannots))
+             (dolist (item (pdf-info-getannots page-number))
                (let* ((type (alist-get 'type item))
                       (page (alist-get 'page item))
                       (edges (or (org-noter--pdf-tools-edges-to-region (alist-get 'markup-edges item))


### PR DESCRIPTION
Add an optional page-number support to import only specific pages instead of all the pages. I think the problem it solves is pretty common:

1. Make some annotations on a pdf
2. Export the skeleton to an org file
3. Add more annotations on a pdf
4. Selectively add annotations from a page range instead of the whole pdf

I want to create some interactive functions to make it easier to use before merging, thus the draft status.

