### PR TITLE
fix links by prefixing getf and find-if with cl-

### DIFF
--- a/org-pdftools.el
+++ b/org-pdftools.el
@@ -140,7 +140,7 @@ with `TO-EXPORT' when exporting links. Also use reverse translation from
 
 (defun org-pdftools-abbreviate-file-name (path)
   "Abbreviate `PATH' using `org-pdftools-path-translations'."
-  (let ((translation-rule (find-if (lambda (rule)
+  (let ((translation-rule (cl-find-if (lambda (rule)
                                      (cl-destructuring-bind (from . to) rule
                                        (string-prefix-p to path)))
                                    org-pdftools-path-translations)))
@@ -155,7 +155,7 @@ with `TO-EXPORT' when exporting links. Also use reverse translation from
   "Expand `PATH' using `RULES'.
 - `RULES' is an alist of (FROM . TO).
 If no rules match, `PATH' is returned as it is."
-  (let ((translation-rule (find-if (lambda (rule)
+  (let ((translation-rule (cl-find-if (lambda (rule)
                                      (cl-destructuring-bind (from . to) rule
                                        (string-prefix-p from path)))
                                    rules)))
@@ -220,7 +220,7 @@ Returns components of the path"
 (defun org-pdftools-open-pdftools (link)
   "Internal function to open org-pdftools LINK."
   (let ((pdf-link (org-pdftools-parse-link link)))
-    (cond ((getf pdf-link :path)
+    (cond ((cl-getf pdf-link :path)
            (cl-destructuring-bind (&key path page height annot-id search-string) pdf-link
              (when (and path
                         (not (string-empty-p path)))
@@ -293,7 +293,7 @@ Returns components of the path"
                  (isearch-mode t)
                  (let (pdf-isearch-narrow-to-page t)
                    (isearch-yank-string search-string))))))
-          ((getf pdf-link :pathlist)
+          ((cl-getf pdf-link :pathlist)
            (pdf-occur-search
             pathlist
             occur-search-string))
@@ -400,9 +400,9 @@ Returns components of the path"
     (if (bound-and-true-p org-pdftools-open-custom-open)
         (funcall org-pdftools-open-custom-open link)
       (let ((pdf-link (org-pdftools-parse-link link)))
-        (if (getf pdf-link :occur-search-string)
+        (if (cl-getf pdf-link :occur-search-string)
             (message "Please install pdf-tools to open pdf-occur links")
-          (org-open-file (getf pdf-link :path)))))))
+          (org-open-file (cl-getf pdf-link :path)))))))
 
 ;;;###autoload
 (defun org-pdftools-store-link ()


### PR DESCRIPTION
This fixes links to pdfs and allows creating new ones, following the suggestions in the discussion of this issue:
https://github.com/fuxialexander/org-pdftools/issues/110